### PR TITLE
feat(RF-06): parser HTTP/1.1 para WS y PIBL.

### DIFF
--- a/pibl/src/http_parser.c
+++ b/pibl/src/http_parser.c
@@ -1,35 +1,22 @@
 /*
  * =============================================================================
- * PIBL - http_parser.c - Parser HTTP para requests y responses
+ * PIBL - http_parser.c - Parser HTTP/1.1 para el proxy (RFC 2616)
  * =============================================================================
  *
  * REQUISITOS QUE DEBE CUMPLIR ESTE ARCHIVO:
- *   1. http_parse_request(): Idéntico al TWS - parsear Request-Line + headers
- *   2. http_find_header(): Buscar un header específico en el buffer
- *      - Ej: http_find_header(buf, "Content-Length") → "1234"
- *      - Case-insensitive
- *   3. http_get_content_length(): Wrapper sobre http_find_header
- *      que retorna el valor como int (atoi)
+ *   1. http_find_header(): Buscar un header especifico en un buffer HTTP.
+ *      - Case-insensitive segun RFC 2616 seccion 4.2
+ *      - Retorna puntero al inicio del valor o NULL si no existe
+ *   2. http_get_content_length(): Wrapper sobre http_find_header que retorna
+ *      el valor de Content-Length como entero. Sirve para que el proxy sepa
+ *      cuantos bytes leer del backend antes de cerrar la conexion.
+ *   3. http_parse_request(): Parsear la peticion del cliente antes de
+ *      reenviarla al backend. Misma logica que el WS.
  *
- * PASOS A TOMAR:
- *   - Paso 1: Copiar la implementación base del TWS http_parser.c
- *   - Paso 2: Agregar http_find_header():
- *       a. Buscar "header_name:" en el buffer (case-insensitive)
- *       b. Saltar espacios después de ":"
- *       c. Retornar puntero al inicio del valor
- *   - Paso 3: http_get_content_length():
- *       a. Llamar http_find_header(buf, "Content-Length")
- *       b. Si encontrado → atoi(valor)
- *       c. Si no → retornar -1
- *
- * CLAVES PARA EL ÉXITO:
- *   - El PIBL necesita parsear tanto requests como responses HTTP
- *   - Para responses, la Status-Line es: "HTTP/1.1 200 OK\r\n"
- *     → NO usar http_parse_request para responses
- *   - Content-Length es CRUCIAL para saber cuándo la respuesta del
- *     backend está completa → sin esto, read() se bloquea esperando más datos
- *   - Headers pueden tener espacios variables: "Content-Length: 1234"
- *     o "Content-Length:1234" → manejar ambos casos
+ * CLAVES PARA EL EXITO:
+ *   - Los headers son case-insensitive: "Content-Length:" == "content-length:"
+ *   - El PIBL usa http_find_header sobre RESPUESTAS del backend,
+ *     no solo sobre peticiones del cliente.
  * =============================================================================
  */
 
@@ -39,3 +26,150 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+
+/*Verifica si el metodo recibido es uno de los 3 que vamos a soportar*/
+static int metodo_soportado(const char *method){
+    if (strcmp(method, "GET") == 0) return 1;
+    if (strcmp(method, "HEAD") == 0) return 1;
+    if (strcmp(method, "POST") == 0) return 1;
+    return 0;
+}
+
+/*Verificacion de version HTTP para verificar que sea unicamente HTTP 1.1*/
+static int version_soportada(const char *version){
+    if (strcmp(version, "HTTP/1.1") == 0) return 1;
+    return 0;
+}
+
+/*
+ * Busca un header especifico dentro del buffer HTTP.
+ * Recorre linea por linea hasta el separador \r\n\r\n comparando el inicio
+ * de cada linea con "header_name:" de forma case-insensitive.
+ *
+ * Retorna: puntero al primer caracter del valor, o NULL si no se encuentra.
+ */
+const char *http_find_header(const char *buffer, const char *header_name){
+    if (buffer == NULL || header_name == NULL){
+        return NULL;
+    }
+
+    size_t nombre_len = strlen(header_name);
+
+    /* Empezar despues del primer CRLF, que cierra la Request-Line o Status-Line */
+    const char *linea = strstr(buffer, "\r\n");
+    if (linea == NULL){
+        return NULL;
+    }
+    linea += 2;
+
+    const char *fin_headers = strstr(buffer, "\r\n\r\n");
+    if (fin_headers == NULL){
+        return NULL;
+    }
+
+    while (linea < fin_headers){
+        /* La linea debe empezar con "header_name" seguido de ':' */
+        if (strncasecmp(linea, header_name, nombre_len) == 0 && linea[nombre_len] == ':'){
+            const char *valor = linea + nombre_len + 1;
+            while (*valor == ' ' || *valor == '\t'){
+                valor++;
+            }
+            return valor;
+        }
+
+        /*Avanzar a la siguiente linea*/
+        const char *siguiente = strstr(linea, "\r\n");
+        if (siguiente == NULL){
+            break;
+        }
+        linea = siguiente + 2;
+    }
+
+    return NULL;
+}
+
+/*
+ * Wrapper sobre http_find_header para extraer Content-Length como entero.
+ * Retorna: valor del header o -1 si no existe.
+ */
+int http_get_content_length(const char *buffer){
+    const char *valor = http_find_header(buffer, "Content-Length");
+    if (valor == NULL){
+        return -1;
+    }
+    return atoi(valor);
+}
+
+int http_parse_request(const char *buffer, http_request_t *req){
+
+    /*Chequear que los parametros esten limpios*/
+    if (buffer == NULL || req == NULL){
+        return -1;
+    }
+
+    /* Limpiar la estructura de salida para que todos los campos queden en 0 */
+    memset(req, 0, sizeof(http_request_t));
+
+    /*
+    PASO 1: parserar la request line en formato "METHOD SP URI SP VERSION CRLF"
+    Ejemplo: "GET /index.html HTTP/1.1"
+    */
+    if (sscanf(buffer,"%7s %2047s %15s", req->method, req->uri, req->version) != 3){
+        return -1;
+    }
+
+    /*
+    Paso 2: el metodo deber ser GET, HEAD o POST
+    */
+    if (!metodo_soportado(req->method)){
+        return -1;
+    }
+
+    /*
+    Paso 3: La version debe ser HTTP/1.1
+    */
+    if (!version_soportada(req->version)){
+        return -1;
+    }
+
+    /*
+    Paso 4: Localizar el separador headers/body
+    * RFC 2616 seccion 4.1: una linea vacia (CRLF CRLF) marca el fin de los
+    * headers y el inicio del body.
+    */
+    const char *fin_headers = strstr(buffer, "\r\n\r\n");
+    if (fin_headers == NULL){
+        return -1;
+    }
+
+    /*
+     * Paso 5: Extraer Host y Content-Length usando http_find_header.
+     * Reutilizamos el helper en lugar de duplicar el loop de headers.
+    */
+    const char *valor_host = http_find_header(buffer, "Host");
+    if (valor_host != NULL){
+        sscanf(valor_host, "%255[^\r\n]", req->host);
+    }
+
+    int cl = http_get_content_length(buffer);
+    if (cl >= 0){
+        req->content_length = cl;
+    }
+
+    /*
+     * Paso 6: Validacion HTTP/1.1: el header Host es obligatorio.
+     * RFC 2616 14.23: "A client MUST include a Host header field in all
+     * HTTP/1.1 request messages."
+    */
+    if (req->host[0] == '\0'){
+        return -1;
+    }
+
+    /*
+     * Paso 7: Apuntar body al inicio del cuerpo del mensaje.
+     * El body empieza inmediatamente despues del separador \r\n\r\n.
+    */
+    req->body = (char *)(fin_headers + 4);
+
+    return 0;
+}

--- a/pibl/src/http_parser.h
+++ b/pibl/src/http_parser.h
@@ -21,12 +21,12 @@
 #define PIBL_HTTP_PARSER_H
 
 typedef struct {
-    char method[8];
-    char uri[2048];
-    char version[16];
-    char host[256];
-    int  content_length;
-    char *body;
+    char method[8]; /* Metodo HTTP: "GET", "HEAD" o "POST" */
+    char uri[2048]; /* Ruta del recurso solicitado, ej: "/index.html" */
+    char version[16]; /* Version del protocolo: "HTTP/1.1" */
+    char host[256]; /* Valor del header Host, obligatorio en HTTP/1.1 */
+    int content_length; /* Valor del header Content-Length (0 si no viene) */
+    char *body; /* Puntero al inicio del body dentro del buffer */
 } http_request_t;
 
 int  http_parse_request(const char *buffer, http_request_t *req);

--- a/ws/src/http_parser.c
+++ b/ws/src/http_parser.c
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * TWS - http_parser.c - Parser de peticiones HTTP/1.1
+ * WS - http_parser.c - Parser de peticiones HTTP/1.1
  * =============================================================================
  *
  * REQUISITOS QUE DEBE CUMPLIR ESTE ARCHIVO:
@@ -9,18 +9,15 @@
  *   2. Parsear los headers línea por línea buscando:
  *      - Host: (obligatorio en HTTP/1.1)
  *      - Content-Length: (necesario para POST)
- *      - Content-Type: (informativo, guardar si se necesita)
- *      - Connection: (keep-alive / close)
  *   3. Validar que method sea GET, HEAD o POST → si no, retornar -1
- *   4. Validar que version sea HTTP/1.0 o HTTP/1.1 → si no, retornar -1
+ *   4. Validar que version sea HTTP/1.1 → si no, retornar -1
  *   5. El body del POST empieza después de "\r\n\r\n"
  *
  * PASOS A TOMAR:
- *   - Paso 1: Copiar buffer a una copia temporal (no modificar original)
- *   - Paso 2: Tokenizar primera línea → method, uri, version
- *   - Paso 3: Loop sobre líneas restantes → buscar headers relevantes
- *   - Paso 4: Si es POST, guardar puntero al body (offset desde "\r\n\r\n")
- *   - Paso 5: Retornar 0 si todo OK, -1 si request malformado
+ *   - Paso 1: Tokenizar primera línea → method, uri, version
+ *   - Paso 2: Loop sobre líneas restantes → buscar headers relevantes
+ *   - Paso 3: Si es POST, guardar puntero al body (offset desde "\r\n\r\n")
+ *   - Paso 4: Retornar 0 si todo OK, -1 si request malformado
  *
  * CLAVES PARA EL ÉXITO:
  *   - Las líneas HTTP terminan en "\r\n" (CRLF), NO solo "\n"
@@ -28,11 +25,9 @@
  *     → usar strcasecmp o convertir a minúsculas
  *   - No confiar en que el request tenga formato perfecto,
  *     si algo falta retornar -1 (→ genera 400 Bad Request)
- *   - El URI puede contener query strings: /page?id=5
- *     → solo usar la parte antes de '?' para buscar archivos
- *   - Sanitizar URI: evitar path traversal ("..") por seguridad
  * =============================================================================
  */
+
 
 #include "http_parser.h"
 
@@ -40,3 +35,118 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+
+/*Verifica si el metodo recibido es uno de los 3 que vamos a soportar*/
+static int metodo_soportado(const char *method){
+    if (strcmp(method, "GET") == 0) return 1;
+    if (strcmp(method, "HEAD") == 0) return 1;
+    if (strcmp(method, "POST") == 0) return 1;
+    return 0;
+}
+
+/*Verificacion de version HTTP para verificar que sea unicamente HTTP 1.1*/
+static int version_soportada(const char *version){
+    if (strcmp(version, "HTTP/1.1") == 0) return 1;
+    return 0;
+}
+
+int http_parse_request(const char *buffer, http_request_t *req){
+
+    /*Chequear que los parametros esten limpios*/
+    if (buffer == NULL || req == NULL){
+        return -1;
+    }
+
+    /* Limpiar la estructura de salida para que todos los campos queden en 0 */
+    memset(req, 0, sizeof(http_request_t));
+
+    /*
+    PASO 1: parserar la request line en formato "METHOD SP URI SP VERSION CRLF" 
+    Ejemplo: "GET /index.html HTTP/1.1" 
+    */
+
+    if (sscanf(buffer,"%7s %2047s %15s", req->method, req->uri, req->version) != 3) {
+        return -1;
+    }
+
+    /*
+    Paso 2: el metodo deber ser GET, HEAD o POST
+    */
+    
+    if(!metodo_soportado(req->method)){
+        return -1;
+    }
+
+    /*
+    Paso 3: La version debe ser HTTP1.1 
+    */
+    if(!version_soportada(req->version)){
+        return -1;
+    }
+
+    /*
+    Paso 4: Localizar el separador headers/body
+    * RFC 2616 seccion 4.1: una linea vacia (CRLF CRLF) marca el fin de los
+    * headers y el inicio del body. Si no aparece, los headers terminan
+    * donde termine el buffer.
+    */
+
+    const char *fin_headers = strstr(buffer, "\r\n\r\n");
+    if (fin_headers == NULL) {
+        return -1;
+    }
+
+    /*
+     * Paso 5: Recorrer las lineas de headers buscando los que nos importan.
+     * Empezamos despues del primer CRLF, que cierra la Request-Line.
+    */
+
+    const char *linea = strstr(buffer, "\r\n");
+    if (linea == NULL){
+        return -1; /*Si la peticion esta mal*/
+    }
+    linea += 2;
+
+    while (linea < fin_headers){
+        /* Host: valor  -> obligatorio en HTTP/1.1 (RFC 2616 14.23) */
+        if (strncasecmp(linea, "Host:", 5) == 0){
+            const char *valor = linea + 5;
+            while (*valor == ' ' || *valor == '\t') {
+                valor++;
+            }
+            sscanf(valor, "%255[^\r\n]", req->host);
+        }
+        /* Content-Length: Valor -> necesario para leer el body de un POST*/
+        else if (strncasecmp(linea, "Content-Length:", 15) == 0){
+            const char *valor = linea + 15;
+            while (*valor == ' ' || *valor == '\t'){
+                valor++;
+            }
+            req->content_length = atoi(valor);
+        }
+
+        /*Avanzar a la siguiente linea*/
+        const char *siguiente = strstr(linea, "\r\n");
+        if (siguiente == NULL){
+            break;
+        }
+        linea = siguiente + 2;  
+    }
+
+    /*
+     * Paso 6: Validacion HTTP/1.1: el header Host es obligatorio.
+     * RFC 2616 14.23: "A client MUST include a Host header field in all
+     * HTTP/1.1 request messages."
+    */
+    if (req->host[0] == '\0'){
+        return -1;
+    }
+
+    /*
+     * Paso 7: Apuntar body al inicio del cuerpo del mensaje.
+     * El body empieza inmediatamente despues del separador \r\n\r\n.
+    */
+    req->body = (char *)(fin_headers + 4);
+
+    return 0;
+}

--- a/ws/src/http_parser.h
+++ b/ws/src/http_parser.h
@@ -1,13 +1,13 @@
 /*
  * =============================================================================
- * TWS - http_parser.h - Interfaz del parser HTTP
+ * WS - http_parser.h - Interfaz del parser HTTP
  * =============================================================================
  *
  * REQUISITOS:
  *   1. Definir la estructura http_request_t con campos:
  *      - method: "GET", "HEAD" o "POST"
  *      - uri: ruta del recurso (ej: "/index.html", "/gallery.html")
- *      - version: "HTTP/1.1" o "HTTP/1.0"
+ *      - version: "HTTP/1.1"
  *      - host: valor del header Host (obligatorio en HTTP/1.1)
  *      - content_length: valor numérico del header Content-Length (para POST)
  *      - body: puntero al cuerpo del request (para POST)
@@ -21,18 +21,22 @@
  *     \r\n
  *     [body si POST]
  * =============================================================================
- */
+*/
 
-#ifndef TWS_HTTP_PARSER_H
-#define TWS_HTTP_PARSER_H
 
+#ifndef WS_HTTP_PARSER_H
+#define WS_HTTP_PARSER_H
+
+/*
+Esta va a ser la estructura con los datos parseados de una peticion HTTP1.1.
+*/
 typedef struct {
-    char method[8];
-    char uri[2048];
-    char version[16];
-    char host[256];
-    int  content_length;
-    char *body;
+    char method[8]; /* Metodo HTTP: "GET", "HEAD" o "POST" */
+    char uri[2048]; /* Ruta del recurso solicitado, ej: "/index.html" */
+    char version[16]; /* Version del protocolo: "HTTP/1.1" */
+    char host[256]; /* Valor del header Host, obligatorio en HTTP/1.1 */
+    int content_length; /* Valor del header Content-Length (0 si no viene) */
+    char *body; /* Puntero al inicio del body dentro del buffer */
 } http_request_t;
 
 int http_parse_request(const char *buffer, http_request_t *req);


### PR DESCRIPTION
Se agregó parser de Request-Line: METHOD URI HTTP/1.1.
Se validan métodos GET, HEAD y POST.
Se rechazan versiones distintas a HTTP/1.1.
Se parsean headers relevantes: Host y Content-Length.
Se exige header Host en peticiones HTTP/1.1.
Se respeta separación headers/body usando \r\n\r\n.
En PIBL se agregó búsqueda genérica de headers con http_find_header() y helper http_get_content_length() para procesar respuestas del backend.
Validado con compilación de ws/src/http_parser.c y pibl/src/http_parser.c usando gcc -Wall -Wextra -std=c99 sin errores.

Merge de RF-06 -> Dev